### PR TITLE
Release 0100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.10.0
+* Dependency Updates 2024-03-19 by @Jammjammjamm in https://github.com/inferno-framework/davinci-us-drug-formulary-test-kit/pull/3
+* Dependency Updates 2024-04-05 by @Jammjammjamm in https://github.com/inferno-framework/davinci-us-drug-formulary-test-kit/pull/4
+* FI-2429: Migrate to HL7 validator wrapper by @dehall in https://github.com/inferno-framework/davinci-us-drug-formulary-test-kit/pull/6
+* Dependency Updates 2024-06-05 by @Jammjammjamm in https://github.com/inferno-framework/davinci-us-drug-formulary-test-kit/pull/8
+* Bump core version in gemspec by @dehall in https://github.com/inferno-framework/davinci-us-drug-formulary-test-kit/pull/7
+
 # 0.9.1
 * Da Vinci -> DaVinci to match IG by @karlnaden in
   https://github.com/inferno-framework/davinci-us-drug-formulary-test-kit/pull/1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    davinci_us_drug_formulary_test_kit (0.9.1)
+    davinci_us_drug_formulary_test_kit (0.10.0)
       inferno_core (>= 0.4.37)
       tls_test_kit (~> 0.2.0)
 
@@ -174,7 +174,7 @@ GEM
     method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.0507)
+    mime-types-data (3.2024.0604)
     mini_portile2 (2.8.7)
     minitest (5.23.1)
     multi_json (1.15.0)
@@ -310,7 +310,7 @@ GEM
     strscan (3.1.0)
     thor (1.2.2)
     tilt (2.3.0)
-    tls_test_kit (0.2.1)
+    tls_test_kit (0.2.2)
       inferno_core (>= 0.4.2)
     tty-color (0.6.0)
     tty-markdown (0.7.2)

--- a/lib/davinci_us_drug_formulary_test_kit/version.rb
+++ b/lib/davinci_us_drug_formulary_test_kit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DaVinciUSDrugFormularyTestKit
-  VERSION = '0.9.1'
+  VERSION = '0.10.0'
 end


### PR DESCRIPTION
# Summary
* Dependency Updates 2024-03-19 by @Jammjammjamm in https://github.com/inferno-framework/davinci-us-drug-formulary-test-kit/pull/3
* Dependency Updates 2024-04-05 by @Jammjammjamm in https://github.com/inferno-framework/davinci-us-drug-formulary-test-kit/pull/4
* FI-2429: Migrate to HL7 validator wrapper by @dehall in https://github.com/inferno-framework/davinci-us-drug-formulary-test-kit/pull/6
* Dependency Updates 2024-06-05 by @Jammjammjamm in https://github.com/inferno-framework/davinci-us-drug-formulary-test-kit/pull/8
* Bump core version in gemspec by @dehall in https://github.com/inferno-framework/davinci-us-drug-formulary-test-kit/pull/7

