### PR TITLE
FI-3815: Update Test Kit with new RSpec features

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,6 +33,22 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          bundler-cache: true
       - name: Run tests
         run: bundle exec rake
+
+  lint:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.3.6']
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+    - name: Rubocop
+      run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.3.6
   Exclude:
     - 'Gemfile'
     - 'lib/davinci_us_drug_formulary_test_kit/generated/**/*'
@@ -68,8 +68,11 @@ RSpec/DescribeClass:
 RSpec/ExampleLength:
   Enabled: false
 
-RSpec/FilePath:
-  Enabled: false
+RSpec/SpecFilePathFormat:
+  Enabled: true
+
+RSpec/SpecFilePathSuffix:
+  Enabled: true
 
 RSpec/MultipleExpectations:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -69,7 +69,7 @@ RSpec/ContextWording:
 # Offense count: 4
 # Configuration parameters: Include, CustomTransform, IgnoreMethods, SpecSuffixOnly.
 # Include: **/*_spec*rb*, **/spec/**/*
-RSpec/FilePath:
+RSpec/SpecFilePathSuffix:
   Exclude:
     - 'spec/us_core/date_search_validation_test_spec.rb'
     - 'spec/us_core/generator/must_support_metadata_extractor_spec.rb'

--- a/Rakefile
+++ b/Rakefile
@@ -44,17 +44,13 @@ namespace :requirements do
     require_relative 'lib/inferno_requirements_tools/tasks/requirements_coverage'
     InfernoRequirementsTools::Tasks::RequirementsCoverage.new.run_check
   end
-end
 
-namespace :requirements do
   desc 'Collect requirements and planned not tested requirements into CSVs'
   task :collect, [:input_directory] => [] do |_t, args|
     require_relative 'lib/inferno_requirements_tools/tasks/collect_requirements'
     InfernoRequirementsTools::Tasks::CollectRequirements.new.run(args.input_directory)
   end
-end
 
-namespace :requirements do
   desc 'Check if requirements and planned not tested CSVs are up-to-date'
   task :check_collection, [:input_directory] => [] do |_t, args|
     require_relative 'lib/inferno_requirements_tools/tasks/collect_requirements'

--- a/davinci_us_drug_formulary_test_kit.gemspec
+++ b/davinci_us_drug_formulary_test_kit.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'tls_test_kit', '~> 0.3.0'
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
   spec.add_development_dependency 'factory_bot', '~> 6.1'
+  spec.add_development_dependency 'roo', '~> 2.10.1'
   spec.add_development_dependency 'rspec', '~> 3.10'
   spec.add_development_dependency 'webmock', '~> 3.11'
-  spec.add_development_dependency 'roo', '~> 2.10.1'
   spec.required_ruby_version = Gem::Requirement.new('>= 3.3.6')
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage

--- a/lib/davinci_us_drug_formulary_test_kit.rb
+++ b/lib/davinci_us_drug_formulary_test_kit.rb
@@ -1,3 +1,3 @@
-require_relative 'davinci_us_drug_formulary_test_kit/metadata.rb'
+require_relative 'davinci_us_drug_formulary_test_kit/metadata'
 require_relative 'inferno_requirements_tools/ext/inferno_core/runnable'
 require_relative 'davinci_us_drug_formulary_test_kit/generated/v2.0.1/usdf_test_suite'

--- a/lib/davinci_us_drug_formulary_test_kit/fhir_resource_navigation.rb
+++ b/lib/davinci_us_drug_formulary_test_kit/fhir_resource_navigation.rb
@@ -16,7 +16,7 @@ module DaVinciUSDrugFormularyTestKit
       end.compact
     end
 
-    def find_a_value_at(element, path, include_dar: false, &block)
+    def find_a_value_at(element, path, include_dar: false, &)
       return nil if element.nil?
 
       elements = Array.wrap(element)
@@ -28,7 +28,7 @@ module DaVinciUSDrugFormularyTestKit
           end
         end
 
-        return elements.find(&block) if block_given?
+        return elements.find(&) if block_given?
 
         return elements.first
       end

--- a/lib/davinci_us_drug_formulary_test_kit/generator/ig_loader.rb
+++ b/lib/davinci_us_drug_formulary_test_kit/generator/ig_loader.rb
@@ -30,7 +30,6 @@ module DaVinciUSDrugFormularyTestKit
       end
 
       def load_ig
-
         tar = Gem::Package::TarReader.new(
           Zlib::GzipReader.open(ig_file_name)
         )

--- a/lib/davinci_us_drug_formulary_test_kit/generator/include_search_test_generator.rb
+++ b/lib/davinci_us_drug_formulary_test_kit/generator/include_search_test_generator.rb
@@ -72,7 +72,9 @@ module DaVinciUSDrugFormularyTestKit
 
       def include_param_resource
         res_type = group_metadata.search_definitions[:"#{include_search_look_up_param}"][:type]
-        res_type = group_metadata.search_definitions[:"#{include_search_look_up_param}"][:target] if res_type == 'Reference'
+        if res_type == 'Reference'
+          res_type = group_metadata.search_definitions[:"#{include_search_look_up_param}"][:target]
+        end
         res_type
       end
     end

--- a/lib/davinci_us_drug_formulary_test_kit/metadata.rb
+++ b/lib/davinci_us_drug_formulary_test_kit/metadata.rb
@@ -1,6 +1,6 @@
 require_relative 'version'
 
-module DaVinciUSDrugFormularyTestKit 
+module DaVinciUSDrugFormularyTestKit
   class Metadata < Inferno::TestKit
     id :davinci_us_drug_formulary_test_kit
     title 'Da Vinci US Drug Formulary Test Kit'
@@ -17,9 +17,9 @@ module DaVinciUSDrugFormularyTestKit
       [DaVinci Payer Data Exchange (PDex) US Drug Formulary Implementation Guide v2.0.1](http://hl7.org/fhir/us/davinci-drug-formulary/STU2.0.1).
 
       <!-- break -->
-  
+
       These tests check the following behaviors as defined in the IG:
-  
+
       - FHIR Interactions
         + Capabilities
         + Read
@@ -30,17 +30,17 @@ module DaVinciUSDrugFormularyTestKit
         + Validation against IG profiles
         + Presence of all Must Support fields
           * Resolution of Must Support references
-  
+
       The DaVinci US Drug Formulary Test Kit is built using the
       [Inferno Framework](https://inferno-framework.github.io/).
       The Inferno Framework is designed for reuse and aims to make it easier to
       build test kits for any FHIR-based data exchange.
-      
+
       ### Known Limitations
-  
+
       The following areas of the IG are not fully tested in this draft version
       of the test kit:
-  
+
       - Must Support checks are not performed for all elements of Formulary Drug
         resources due to the use of an intensional value set for slicing
         `MedicationKnowledge.code.coding` elements.
@@ -49,9 +49,9 @@ module DaVinciUSDrugFormularyTestKit
         + Multiple Or
         + Multiple And
         + Comparators
-  
+
       ## Reporting Issues
-  
+
       Please report any issues with this set of tests in the
       [GitHub Issues](https://github.com/inferno-framework/davinci-us-drug-formulary-test-kit/issues)
       section of this repository.

--- a/lib/davinci_us_drug_formulary_test_kit/search_test.rb
+++ b/lib/davinci_us_drug_formulary_test_kit/search_test.rb
@@ -49,7 +49,6 @@ module DaVinciUSDrugFormularyTestKit
     def all_include_search_params
       @all_include_search_params ||=
         search_param_names.each_with_object({}) do |value, params|
-
           params[value] ||= fixed_value_search_param_values.filter_map do |fixed_value|
             fixed_value_search_params(fixed_value, value).merge('_include' => include_param)
           end
@@ -272,7 +271,7 @@ module DaVinciUSDrugFormularyTestKit
 
           search_and_check_response(params_with_comparator)
 
-          fetch_all_bundled_resources(resource_type: resource_type, bundle: resource).each do |resource|
+          fetch_all_bundled_resources(resource_type:, bundle: resource).each do |resource|
             check_resource_against_params(resource, params_with_comparator) if resource.resourceType == resource_type
           end
         end
@@ -504,11 +503,13 @@ module DaVinciUSDrugFormularyTestKit
 
     def select_all_bundled_resources
       if resource_type == 'MedicationRequest'
-        fetch_all_bundled_resources(resource_type: resource_type, bundle: resource, additional_resource_types: ['Medication'])
-          .select{ |resource| resource.resourceType == resource_type }
+        fetch_all_bundled_resources(resource_type:, bundle: resource, additional_resource_types: ['Medication'])
+          .select do |resource|
+          resource.resourceType == resource_type
+        end
       else
-        fetch_all_bundled_resources(resource_type: resource_type, bundle: resource)
-          .select{ |resource| resource.resourceType == resource_type }
+        fetch_all_bundled_resources(resource_type:, bundle: resource)
+          .select { |resource| resource.resourceType == resource_type }
       end
     end
 

--- a/spec/davinci_us_drug_formulary_test_kit/must_support_test_spec.rb
+++ b/spec/davinci_us_drug_formulary_test_kit/must_support_test_spec.rb
@@ -1,24 +1,7 @@
 require_relative '../../lib/davinci_us_drug_formulary_test_kit/must_support_test'
 
-RSpec.describe DaVinciUSDrugFormularyTestKit::MustSupportTest do
-  let(:suite) { Inferno::Repositories::TestSuites.new.find('davinci_us_drug_formulary_v201') }
-  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
-  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
-  # let(:patient_ref) { 'Patient/85' }
-
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-    inputs.each do |name, value|
-      session_data_repo.save(
-        test_session_id: test_session.id,
-        name:,
-        value:,
-        type: runnable.config.input_type(name)
-      )
-    end
-    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
-  end
+RSpec.describe DaVinciUSDrugFormularyTestKit::MustSupportTest, :runnable do
+  let(:suite_id) { 'davinci_us_drug_formulary_v201' }
 
   describe 'must support test for MedicationKnowledge elements' do
     let(:medication_must_support_test) do

--- a/spec/davinci_us_drug_formulary_test_kit/profile_support_test_spec.rb
+++ b/spec/davinci_us_drug_formulary_test_kit/profile_support_test_spec.rb
@@ -1,6 +1,5 @@
 require_relative '../../lib/davinci_us_drug_formulary_test_kit/custom_groups/capability_statement/profile_support_test'
 
-
 RSpec.describe DaVinciUSDrugFormularyTestKit::ProfileSupportTest do
   let(:suite_id) { 'davinci_us_drug_formulary_v201' }
   let(:test) { described_class }

--- a/spec/davinci_us_drug_formulary_test_kit/profile_support_test_spec.rb
+++ b/spec/davinci_us_drug_formulary_test_kit/profile_support_test_spec.rb
@@ -1,25 +1,8 @@
-require_relative(
-  '../../lib/davinci_us_drug_formulary_test_kit/custom_groups/capability_statement/profile_support_test'
-)
+require_relative '../../lib/davinci_us_drug_formulary_test_kit/custom_groups/capability_statement/profile_support_test'
+
 
 RSpec.describe DaVinciUSDrugFormularyTestKit::ProfileSupportTest do
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-    inputs.each do |name, value|
-      session_data_repo.save(
-        test_session_id: test_session.id,
-        name:,
-        value:,
-        type: runnable.config.input_type(name) || 'text'
-      )
-    end
-    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
-  end
-
-  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
-  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
-  let(:suite) { Inferno::Repositories::TestSuites.new.find('usdf_v200') }
+  let(:suite_id) { 'davinci_us_drug_formulary_v201' }
   let(:test) { described_class }
   let(:url) { 'http://example.com/fhir' }
 
@@ -29,7 +12,9 @@ RSpec.describe DaVinciUSDrugFormularyTestKit::ProfileSupportTest do
         OpenStruct.new(
           options: {
             # omitting 'GraphDefinition'
-            required_resources: ['InsurancePlan', 'Basic', 'MedicationKnowledge',
+            required_resources: ['InsurancePlan',
+                                 'Basic',
+                                 'MedicationKnowledge',
                                  'Location']
           }
         )
@@ -61,7 +46,7 @@ RSpec.describe DaVinciUSDrugFormularyTestKit::ProfileSupportTest do
         ).to_json
       repo_create(:request, response_body:, name: 'capability_statement', test_session_id: test_session.id)
 
-      result = run(test, url:)
+      result = run(test)
 
       expect(result.result).to eq('fail')
       expect(result.result_message).to include('Location')
@@ -95,7 +80,7 @@ RSpec.describe DaVinciUSDrugFormularyTestKit::ProfileSupportTest do
         ).to_json
       repo_create(:request, response_body:, name: 'capability_statement', test_session_id: test_session.id)
 
-      result = run(test, url:)
+      result = run(test)
 
       expect(result.result).to eq('pass')
     end
@@ -130,7 +115,7 @@ RSpec.describe DaVinciUSDrugFormularyTestKit::ProfileSupportTest do
         ).to_json
       repo_create(:request, response_body:, name: 'capability_statement', test_session_id: test_session.id)
 
-      result = run(test, url:)
+      result = run(test)
       expect(result.result).to eq('pass')
     end
   end

--- a/spec/davinci_us_drug_formulary_test_kit/reference_resolution_test_spec.rb
+++ b/spec/davinci_us_drug_formulary_test_kit/reference_resolution_test_spec.rb
@@ -1,19 +1,7 @@
 require_relative '../../lib/davinci_us_drug_formulary_test_kit/reference_resolution_test'
 
-RSpec.describe DaVinciUSDrugFormularyTestKit::ReferenceResolutionTest do
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-    inputs.each do |name, value|
-      session_data_repo.save(
-        test_session_id: test_session.id,
-        name:,
-        value:,
-        type: runnable.config.input_type(name)
-      )
-    end
-    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
-  end
+RSpec.describe DaVinciUSDrugFormularyTestKit::ReferenceResolutionTest, :runnable do
+  let(:suite_id) { 'davinci_us_drug_formulary_v201' }
 
   describe '#validate_reference_resolution' do
     let(:test_class) do
@@ -216,9 +204,6 @@ RSpec.describe DaVinciUSDrugFormularyTestKit::ReferenceResolutionTest do
   end
 
   describe '#perform_reference_resolution_test' do
-    let(:suite) { Inferno::Repositories::TestSuites.new.find('davinci_us_drug_formulary_v201') }
-    let(:session_data_repo) { Inferno::Repositories::SessionData.new }
-    let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
     let(:url) { 'http://example.com/fhir' }
     let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
 

--- a/spec/davinci_us_drug_formulary_test_kit/search_test_spec.rb
+++ b/spec/davinci_us_drug_formulary_test_kit/search_test_spec.rb
@@ -1,21 +1,9 @@
 require_relative '../../lib/davinci_us_drug_formulary_test_kit/search_test'
 
-RSpec.describe DaVinciUSDrugFormularyTestKit::SearchTest do
-  let(:suite) { Inferno::Repositories::TestSuites.new.find('davinci_us_drug_formulary_v201') }
-  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
-  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
+RSpec.describe DaVinciUSDrugFormularyTestKit::SearchTest, :runnable do
+  let(:suite_id) { 'davinci_us_drug_formulary_v201' }
   let(:url) { 'http://example.com/fhir' }
   let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
-
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-    inputs.each do |name, value|
-      session_data_repo.save(test_session_id: test_session.id, name:, value:,
-                             type: runnable.config.input_type(name))
-    end
-    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
-  end
 
   # 1. Search for each of the 4 profiles types
   # 2. RESTful behavior according to FHIR spec
@@ -91,6 +79,7 @@ RSpec.describe DaVinciUSDrugFormularyTestKit::SearchTest do
     let(:bundle) { FHIR::Bundle.new(entry: [{ resource: medication_knowledge1 }]) }
     let(:test_scratch) { {} }
 
+    # TODO: comment out? - shaumik
     before do
       Inferno::Repositories::Tests.new.insert(medication_knowledge_search_test)
       allow_any_instance_of(medication_knowledge_search_test)


### PR DESCRIPTION
# Summary
 - Replaces local code with helpers from inferno core rspec support
 - Fixes profile_support_test_spec.rb
 - Fix rubocop and lint

# Testing Guidance
 1. Checkout branch
 2. `bundle exec rspec`
