### PR TITLE
Fix input for v and a tests

### DIFF
--- a/lib/davinci_us_drug_formulary_test_kit/generated/v2.0.1/usdf_test_suite.rb
+++ b/lib/davinci_us_drug_formulary_test_kit/generated/v2.0.1/usdf_test_suite.rb
@@ -1,4 +1,5 @@
 require_relative '../../version'
+require_relative '../../generator'
 require_relative 'urls'
 require_relative '../../custom_groups/v2.0.1/capability_statement_group'
 require_relative 'payer_insurance_plan_group'
@@ -205,9 +206,10 @@ module DaVinciUSDrugFormularyTestKit
                               'hl7.fhir.us.davinci-drug-formulary_2.0.1@34', 'hl7.fhir.us.davinci-drug-formulary_2.0.1@35'
       end
       
-      group from: :usdf_v201_visual_inspection_and_attestation do
-        optional
-      end
+      group from: :usdf_v201_visual_inspection_and_attestation,
+        optional: true
+      Generator::recursive_remove_input(groups.last, :url)
+      Generator::recursive_remove_input(groups.last, :smart_auth_info)
     end
   end
 end

--- a/lib/davinci_us_drug_formulary_test_kit/generated/v2.0.1/usdf_test_suite.rb
+++ b/lib/davinci_us_drug_formulary_test_kit/generated/v2.0.1/usdf_test_suite.rb
@@ -1,5 +1,5 @@
 require_relative '../../version'
-require_relative '../../generator'
+require_relative '../../remove_input'
 require_relative 'urls'
 require_relative '../../custom_groups/v2.0.1/capability_statement_group'
 require_relative 'payer_insurance_plan_group'
@@ -208,8 +208,8 @@ module DaVinciUSDrugFormularyTestKit
       
       group from: :usdf_v201_visual_inspection_and_attestation,
         optional: true
-      Generator::recursive_remove_input(groups.last, :url)
-      Generator::recursive_remove_input(groups.last, :smart_auth_info)
+      RemoveInput::recursive_remove_input(groups.last, :url)
+      RemoveInput::recursive_remove_input(groups.last, :smart_auth_info)
     end
   end
 end

--- a/lib/davinci_us_drug_formulary_test_kit/generator.rb
+++ b/lib/davinci_us_drug_formulary_test_kit/generator.rb
@@ -96,5 +96,11 @@ module DaVinciUSDrugFormularyTestKit
     def generate_urls
       UrlsGenerator.generate(ig_metadata, base_output_dir)
     end
+
+    def self.recursive_remove_input(runnable, input)
+      runnable.inputs.delete(input)
+      runnable.input_order.delete(input)
+      runnable.children.each { |child_runnable| recursive_remove_input(child_runnable, input) }
+    end
   end
 end

--- a/lib/davinci_us_drug_formulary_test_kit/generator.rb
+++ b/lib/davinci_us_drug_formulary_test_kit/generator.rb
@@ -96,11 +96,5 @@ module DaVinciUSDrugFormularyTestKit
     def generate_urls
       UrlsGenerator.generate(ig_metadata, base_output_dir)
     end
-
-    def self.recursive_remove_input(runnable, input)
-      runnable.inputs.delete(input)
-      runnable.input_order.delete(input)
-      runnable.children.each { |child_runnable| recursive_remove_input(child_runnable, input) }
-    end
   end
 end

--- a/lib/davinci_us_drug_formulary_test_kit/generator/templates/suite.rb.erb
+++ b/lib/davinci_us_drug_formulary_test_kit/generator/templates/suite.rb.erb
@@ -1,4 +1,5 @@
 require_relative '../../version'
+require_relative '../../generator'
 require_relative 'urls'
 require_relative '<%= capability_statement_file_name %>'
 <% group_file_list.each do |file_name| %>require_relative '<%= file_name %>'
@@ -171,9 +172,10 @@ module DaVinciUSDrugFormularyTestKit
       end
       <% end %>
       <%- if module_name.include?('USDFV201') -%>
-      group from: :usdf_v201_visual_inspection_and_attestation do
-        optional
-      end
+      group from: :usdf_v201_visual_inspection_and_attestation,
+        optional: true
+      Generator::recursive_remove_input(groups.last, :url)
+      Generator::recursive_remove_input(groups.last, :smart_auth_info)
       <%- end -%>
     end
   end

--- a/lib/davinci_us_drug_formulary_test_kit/generator/templates/suite.rb.erb
+++ b/lib/davinci_us_drug_formulary_test_kit/generator/templates/suite.rb.erb
@@ -1,5 +1,5 @@
 require_relative '../../version'
-require_relative '../../generator'
+require_relative '../../remove_input'
 require_relative 'urls'
 require_relative '<%= capability_statement_file_name %>'
 <% group_file_list.each do |file_name| %>require_relative '<%= file_name %>'
@@ -174,8 +174,8 @@ module DaVinciUSDrugFormularyTestKit
       <%- if module_name.include?('USDFV201') -%>
       group from: :usdf_v201_visual_inspection_and_attestation,
         optional: true
-      Generator::recursive_remove_input(groups.last, :url)
-      Generator::recursive_remove_input(groups.last, :smart_auth_info)
+      RemoveInput::recursive_remove_input(groups.last, :url)
+      RemoveInput::recursive_remove_input(groups.last, :smart_auth_info)
       <%- end -%>
     end
   end

--- a/lib/davinci_us_drug_formulary_test_kit/remove_input.rb
+++ b/lib/davinci_us_drug_formulary_test_kit/remove_input.rb
@@ -1,0 +1,11 @@
+module DaVinciUSDrugFormularyTestKit
+  module RemoveInput
+    module_function
+
+    def recursive_remove_input(runnable, input)
+      runnable.inputs.delete(input)
+      runnable.input_order.delete(input)
+      runnable.children.each { |child_runnable| recursive_remove_input(child_runnable, input) }
+    end
+  end
+end


### PR DESCRIPTION
# Summary

removing url and oath inputs from visual inspection and attestation tests.

# Testing Guidance
- Go to visual inspection and attestation tests
- Run tests and confirm that nothing requests a fhir url

